### PR TITLE
Track fitness metric in GA results

### DIFF
--- a/Gal_GA_PP.py
+++ b/Gal_GA_PP.py
@@ -823,12 +823,17 @@ class GalacticEvolutionGA:
                  f'sfe: {sfe_val:.5f}, delta_sfe: {delta_sfe_val:.3f}, imf_upper: {imf_upper:.1f}, '
                  f'mgal: {mgal:.2e}, nb: {nb:.2e}')
                  
-        # Create metrics list for results storage
-        metrics = [comp_idx, imf_idx, sn1a_idx, sy_idx, sn1ar_idx,
-                   sigma_2, t_1, t_2, infall_1, infall_2, 
-                   sfe_val, delta_sfe_val, imf_upper, mgal, nb,
-                   ks, ensemble, wrmse, mae, mape, huber, cos_similarity, log_cosh]
-        
+        # Create metrics list for results storage.  Include the final
+        # fitness value (after physics penalty) so it can be tracked
+        # alongside the other loss metrics.
+        metrics = [
+            comp_idx, imf_idx, sn1a_idx, sy_idx, sn1ar_idx,
+            sigma_2, t_1, t_2, infall_1, infall_2,
+            sfe_val, delta_sfe_val, imf_upper, mgal, nb,
+            ks, ensemble, wrmse, mae, mape, huber,
+            cos_similarity, log_cosh, primary_loss_value,
+        ]
+
         result = {
             'label': label,
             'MDF_x_data': MDF_x_data,
@@ -837,6 +842,7 @@ class GalacticEvolutionGA:
             'age_y_data': age_y_data,
             'alpha_arrs': alpha_arrs,
             'metrics': metrics,
+            'fitness': primary_loss_value,
             'cs_MDF': cs_MDF,
             'model_number': self.model_count
         }
@@ -970,7 +976,8 @@ class GalacticEvolutionGA:
             'comp_idx', 'imf_idx', 'sn1a_idx', 'sy_idx', 'sn1ar_idx',
             'sigma_2', 't_1', 't_2', 'infall_1', 'infall_2',
             'sfe', 'delta_sfe', 'imf_upper', 'mgal', 'nb',
-            'ks', 'ensemble', 'wrmse', 'mae', 'mape', 'huber', 'cosine', 'log_cosh'
+            'ks', 'ensemble', 'wrmse', 'mae', 'mape', 'huber',
+            'cosine', 'log_cosh', 'fitness'
         ]
 
         df = pd.DataFrame(self.results, columns=col_names)

--- a/MDF_GA.py
+++ b/MDF_GA.py
@@ -185,9 +185,10 @@ def run_ga(cp_manager):
     # Define column names based on the structure of GalGA.results
     col_names = [
         'comp_idx', 'imf_idx', 'sn1a_idx', 'sy_idx', 'sn1ar_idx',
-        'sigma_2', 't_1', 't_2', 'infall_1', 'infall_2', 
+        'sigma_2', 't_1', 't_2', 'infall_1', 'infall_2',
         'sfe', 'delta_sfe', 'imf_upper', 'mgal', 'nb',
-        'ks', 'ensemble', 'wrmse', 'mae', 'mape', 'huber', 'cosine', 'log_cosh'
+        'ks', 'ensemble', 'wrmse', 'mae', 'mape', 'huber',
+        'cosine', 'log_cosh', 'fitness'
     ]
 
     # Create DataFrame from results

--- a/mdf_plotting.py
+++ b/mdf_plotting.py
@@ -354,14 +354,15 @@ def plot_walker_loss_history(walker_history, results_csv='GA/simulation_results.
     
     # Define column mapping based on your results structure
     loss_metrics = {
-        'ks': 14,
-        'ensemble': 15, 
-        'wrmse': 16, 
-        'mae': 17, 
-        'mape': 18, 
-        'huber': 19, 
-        'cosine': 20, 
-        'log_cosh': 21
+        'ks': 15,
+        'ensemble': 16,
+        'wrmse': 17,
+        'mae': 18,
+        'mape': 19,
+        'huber': 20,
+        'cosine': 21,
+        'log_cosh': 22,
+        'fitness': 23,
     }
     
     # Make sure the loss metric exists in our mapping
@@ -1103,7 +1104,7 @@ def extract_metrics(results_file):
 
     # Extract metrics
     metrics_dict = {}
-    for metric in ['wrmse', 'mae', 'mape', 'huber', 'cosine', 'log_cosh', 'ks', 'ensemble']:
+    for metric in ['wrmse', 'mae', 'mape', 'huber', 'cosine', 'log_cosh', 'ks', 'ensemble', 'fitness']:
         if metric in df.columns:
             metrics_dict[metric] = df[metric].values
     
@@ -1452,7 +1453,7 @@ def generate_all_plots(GalGA, feh, normalized_count, results_file='GA/simulation
     
     # 6. Plot loss history for each walker
     print("Generating walker loss history plots...")
-    for metric in ['wrmse', 'huber', 'ks', 'cosine']:
+    for metric in ['wrmse', 'huber', 'ks', 'cosine', 'fitness']:
         plot_walker_loss_history(GalGA.walker_history, results_file, loss_metric=metric)
         
     # 7. Create 3D animation


### PR DESCRIPTION
## Summary
- record GA fitness alongside other loss metrics
- include fitness column in checkpoint outputs and plot generation
- allow plotting fitness history per walker

## Testing
- `python -m py_compile Gal_GA_PP.py MDF_GA.py mdf_plotting.py`

------
https://chatgpt.com/codex/tasks/task_e_686b21b096688321afe36a991d9b33f0